### PR TITLE
BuildConfiguration Improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,137 @@
+
 val web3jVersion = "3.1.0"
 
+lazy val demo = project
+  .settings(
+    name := "demo",
+    // define the statements to be evaluated when entering 'console' and 'consoleQuick' but not 'consoleProject'
+    initialCommands in console := """import java.math.BigInteger
+                                    |import java.util.concurrent.Future
+                                    |import org.web3j.protocol._
+                                    |import org.web3j.protocol.infura._
+                                    |""".stripMargin,
+    unmanagedSourceDirectories in Compile += baseDirectory.value / "../abiWrapper"
+  )
+  .aggregate(root)
+  .dependsOn(root)
+
+lazy val root = (project in file("root"))
+  .settings(
+    name := "root",
+    // define the statements initially evaluated when entering 'console', 'console-quick', but not 'console-project'
+    initialCommands in console := """
+                                    |""".stripMargin,
+  )
+  .settings(
+    libraryDependencies ++= Seq(
+      // Dependencies
+      library.scalaJava8Compact   % Compile,
+      library.logbackClassic      % Compile,
+      // See https://docs.web3j.io/modules.html
+      library.web3jAbiModule      % Compile withSources(), // Application Binary Interface encoders
+      library.web3jCodeGenModule  % Compile withSources(), // Code generators
+      library.web3jCmdModule      % Compile withSources(), // Command-line tools
+      library.web3jCoreModule     % Compile withSources(),
+      library.web3jCryptoModule   % Compile withSources(), // For transaction signing and key/wallet management
+      library.web3jGethModule     % Compile withSources(), // Geth-specific JSON-RPC module
+      library.web3jInfuraModule   % Compile withSources(), // Infura-specific HTTP header support
+      library.web3jParityModule   % Compile withSources(), // Parity-specific JSON-RPC module
+      library.web3jRlpModule      % Compile withSources(), // Recursive Length Prefix (RLP) encoders
+      library.web3jUtilsModule    % Compile withSources(), // Minimal set of utility classes
+      library.web3jMavenPlugin    % Compile withSources(), // Create Java classes from solidity contract files
+      // Testing Dependencies
+      library.scalaTest           % Test    withSources(),
+      library.junitFramework      % Test
+    ).map(dependencies =>
+      library.exclusions.foldRight(dependencies) { (rule, module) =>
+        module.excludeAll(rule)
+      })
+  )
+  .enablePlugins(BuildInfoPlugin)
+  .settings(commonSettings)
+  .settings(commonLoggingSettings)
+  .settings(resolvers           ++= commonResolvers)
+  .settings(libraryDependencies ++= commonDependencies)
+
+
+
+lazy val library =
+  new {
+    object Version {
+      val commonsIo         = "2.6"
+      val scoptV            = "3.7.0"
+      val logback           = "1.2.3"
+      val junit             = "4.12"
+      val pureConfig        = "0.8.0"
+      val scalaFmt          = "1.3.0"
+      val scalaTest         = "3.0.3"
+      val scapeGoat         = "1.3.3"
+      val scalaJava8compat  = "0.8.0"
+      val web3j             = web3jVersion
+      val web3jMaven        = "0.1.2"
+    }
+    val apacheCommonsIo       = "commons-io"                 %  "commons-io"          % Version.commonsIo
+    val scalaJava8Compact     = "org.scala-lang.modules"     %% "scala-java8-compat"  % Version.scalaJava8compat
+    val scalaTest             = "org.scalatest"              %% "scalatest"           % Version.scalaTest
+    val scopt                 = "com.github.scopt"           %% "scopt"               % Version.scoptV
+    val logbackClassic        = "ch.qos.logback"             %  "logback-classic"     % Version.logback
+    val junitFramework        = "junit"                      %  "junit"               % Version.junit
+    val web3jAbiModule        = "org.web3j"                  %  "abi"                 % Version.web3j
+    val web3jCodeGenModule    = "org.web3j"                  %  "codegen"             % Version.web3j
+    val web3jCmdModule        = "org.web3j"                  %  "console"             % Version.web3j
+    val web3jCoreModule       = "org.web3j"                  %  "core"                % Version.web3j
+    val web3jCryptoModule     = "org.web3j"                  %  "crypto"              % Version.web3j
+    val web3jGethModule       = "org.web3j"                  %  "geth"                % Version.web3j
+    val web3jInfuraModule     = "org.web3j"                  %  "infura"              % Version.web3j
+    val web3jParityModule     = "org.web3j"                  %  "parity"              % Version.web3j
+    val web3jRlpModule        = "org.web3j"                  %  "rlp"                 % Version.web3j
+    val web3jUtilsModule      = "org.web3j"                  %  "utils"               % Version.web3j
+    val web3jMavenPlugin      = "org.web3j"                  %  "web3j-maven-plugin"  % Version.web3jMaven
+
+    //  "org.web3j"              %  "tuples"                % web3jVersion withSources(), // See http://www.javatuples.org ... not needed for Scala?
+    //  "org.web3j"              %  "quorum"                % "0.7.0"      withSources(), // integration with JP Morgan's Quorum
+
+    // All exclusions that should be applied to every module.
+    val exclusions = Seq(
+        // Exclusions
+    )
+  }
+
 lazy val commonSettings = Seq(
-  cancelable := true,
 
-  buildInfoKeys ++= Seq[BuildInfoKey]( // assumes that the git repo directory has not been renamed
-    "gitRepoName" -> new File(sys.props("user.dir")).getName
-  ),
+  // Version Configuration
+  scalaVersion := "2.12.4",
+  version      := "0.5.0",
 
-  developers := List(
-    Developer("mslinn",
-              "Mike Slinn",
-              "mslinn@micronauticsresearch.com",
-              url("https://github.com/mslinn")
+  // Project Meta Information
+  organization := "com.micronautics",
+  licenses     += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+  developers   := List(
+    Developer(
+      "mslinn",
+      "Mike Slinn",
+      "mslinn@micronauticsresearch.com",
+      url("https://github.com/mslinn")
     )
   ),
+  // http://www.scala-sbt.org/0.12.4/api/sbt/ScmInfo.html
+  scmInfo       := Some(
+    ScmInfo(
+      url("https://github.com/mslinn/web3j-scala"),
+      "git@github.com:mslinn/web3j-scala.git"
+    )
+  ),
+  // Buildinfo
+  buildInfoKeys ++= Seq[BuildInfoKey](organization, name, version, developers),
 
+  // Set compilation process to be interruptible
+  cancelable   := true,
+  // Fork all Test-Tasks
+  fork         := true,
   // define the statements initially evaluated when entering 'console', 'console-quick', but not 'console-project'
   initialCommands in console := """
                                   |""".stripMargin,
+
   javacOptions ++= Seq(
     "-Xlint:deprecation",
     "-Xlint:unchecked",
@@ -25,33 +139,6 @@ lazy val commonSettings = Seq(
     "-target", "1.8",
     "-g:vars"
   ),
-
-  libraryDependencies ++= Seq(
-    "commons-io"              %  "commons-io"      % "2.6"    withSources(),
-    "ch.qos.logback"          %  "logback-classic" % "1.2.3",
-    "com.github.scopt"        %% "scopt"           % "3.7.0"  withSources(),
-    //
-     "org.scalatest"          %% "scalatest"       % "3.0.3" % Test withSources(),
-     "junit"                  %  "junit"           % "4.12"  % Test
-  ),
-
-  licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
-
-  logLevel := Level.Warn,
-
-  // Only show warnings and errors on the screen for compilations.
-  // This applies to both test:compile and compile and is Info by default
-  logLevel in compile := Level.Warn,
-
-  // Level.INFO is needed to see detailed output when running tests
-  logLevel in test := Level.Info,
-
-  organization := "com.micronautics",
-
-  resolvers ++= Seq(
-    "Ethereum Maven" at "https://dl.bintray.com/ethereum/maven/"
-  ),
-
   scalacOptions ++= Seq( // From https://tpolecat.github.io/2017/04/25/scalac-flags.html
     "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
     "-encoding", "utf-8",                // Specify character encoding used by source files.
@@ -99,63 +186,32 @@ lazy val commonSettings = Seq(
     //"-Ywarn-unused:privates",            // Warn if a private member is unused.
     //"-Ywarn-value-discard"               // Warn when non-Unit expression results are unused.
   ),
-
   // The REPL can’t cope with -Ywarn-unused:imports or -Xfatal-warnings so turn them off for the console
-  scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
-
-  scmInfo := Some(
-    ScmInfo(
-      url("https://github.com/mslinn/web3j-scala"),
-      "git@github.com:mslinn/web3j-scala.git"
-    )
-  ),
-
-  version := "0.5.0"
+  scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
 )
 
-lazy val demo = project
-  .aggregate(root)
-  .settings(
-    // define the statements to be evaluated when entering 'console' and 'consoleQuick' but not 'consoleProject'
-    initialCommands in console := """import java.math.BigInteger
-                                    |import java.util.concurrent.Future
-                                    |import org.web3j.protocol._
-                                    |import org.web3j.protocol.infura._
-                                    |""".stripMargin,
+// Common Dependencies
+lazy val commonDependencies    = Seq(
+  // Dependencies
+  library.apacheCommonsIo   % Compile   withSources(),
+  library.logbackClassic    % Compile,
+  library.scopt             % Compile   withSources(),
+  // Testing Dependencies
+  library.scalaTest         % Test      withSources(),
+  library.junitFramework    % Test
+)
 
-    name := "demo",
+// Common Settings
+lazy val commonLoggingSettings = Seq(
+  logLevel            :=  Level.Warn,
+  // Only show warnings and errors on the screen for compilations.
+  // This applies to both test:compile and compile and is Info by default
+  logLevel in compile :=  Level.Warn,
+  // Level.INFO is needed to see detailed output when running tests
+  logLevel in test    :=  Level.Info,
+)
 
-    unmanagedSourceDirectories in Compile += baseDirectory.value / "../abiWrapper"
-  ).dependsOn(root)
-
-lazy val root = (project in file("root"))
-  .settings(
-    // define the statements initially evaluated when entering 'console', 'console-quick', but not 'console-project'
-    initialCommands in console := """
-                                    |""".stripMargin,
-
-    libraryDependencies ++= Seq(
-      // See https://docs.web3j.io/modules.html
-      "org.web3j"              %  "abi"                   % web3jVersion withSources(), // Application Binary Interface encoders
-      "org.web3j"              %  "codegen"               % web3jVersion withSources(), // Code generators
-      "org.web3j"              %  "console"               % web3jVersion withSources(), // Command-line tools
-      "org.web3j"              %  "core"                  % web3jVersion withSources(),
-      "org.web3j"              %  "crypto"                % web3jVersion withSources(), // For transaction signing and key/wallet management
-      "org.web3j"              %  "geth"                  % web3jVersion withSources(), // Geth-specific JSON-RPC module
-      "org.web3j"              %  "infura"                % web3jVersion withSources(), // Infura-specific HTTP header support
-      "org.web3j"              %  "parity"                % web3jVersion withSources(), // Parity-specific JSON-RPC module
-    //  "org.web3j"              %  "quorum"                % "0.7.0"      withSources(), // integration with JP Morgan's Quorum
-      "org.web3j"              %  "rlp"                   % web3jVersion withSources(), // Recursive Length Prefix (RLP) encoders
-    //  "org.web3j"              %  "tuples"                % web3jVersion withSources(), // See http://www.javatuples.org ... not needed for Scala?
-      "org.web3j"              %  "utils"                 % web3jVersion withSources(), // Minimal set of utility classes
-      "org.web3j"              %  "web3j-maven-plugin"    % "0.1.2"      withSources(), // Create Java classes from solidity contract files
-      //
-      "org.scala-lang.modules" %% "scala-java8-compat"    % "0.8.0",
-      "ch.qos.logback"         %  "logback-classic"       % "1.2.3",
-      //
-      "org.scalatest"          %% "scalatest"   % "3.0.3" % Test withSources(),
-      "junit"                  %  "junit"       % "4.12"  % Test
-    ),
-
-    name := "root"
-  )
+// Common Resolvers
+lazy val commonResolvers = Seq(
+    "Ethereum Maven" at "https://dl.bintray.com/ethereum/maven/"
+)


### PR DESCRIPTION
`build.sbt`  minor fixes + a structuring proposal.

**Motivation:**
The project would benefit from more type safety inside dependency management. Especially version numbers could be easily mistaken - this can lead to a jar-hell scenario. 
A well documented and structured build file is beneficial for attracting new contributors, since it is often the entry point if you get know the project structure.

**PR** 
- Refactored the dependency management in more type-safe manner.
- Improved the readability of `commonSettings`
- Enabled the usage of `commonSettings` by the `root` project
- Enabled the `buildInfo` plugin be used by the `root` project.
- Added Scala Version inside the `commonSettings`
- Enabled forking in `tests`
- Implemented a general concept (proposal) to deal with exclusions in dependencies
