### PR TITLE
Fallback to project path if not found in sys PATH

### DIFF
--- a/src/main/scala/com/micronautics/web3j/Cmd.scala
+++ b/src/main/scala/com/micronautics/web3j/Cmd.scala
@@ -22,7 +22,12 @@ object Cmd {
       .split(Pattern.quote(File.pathSeparator))
       .map(Paths.get(_))
       .find(path => Files.exists(path.resolve(program)))
-      .map(_.resolve(program))
+      .map(_.resolve(program)).orElse(
+        Paths.get("").resolve(program) match {
+          case path if Files.exists(path) => Some(path)
+          case _ => None
+        }
+      )
   }
 
   @inline protected def whichOrThrow(program: String): Path =


### PR DESCRIPTION
Added fallback option if program is not found on system path. Now scripts at PROJECT_HOME/bin are also found without adding them to system path. Handy if you may use this lib and various versions of scripts in multiple projects. 
Also fixes an error - in Linux finding bin/web3j resulted in an error even after creating a symlink under /usr/local/bin, somehow it did not handle the relative path well.